### PR TITLE
Pair spectrometer in GoAT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ set(GOAT_BASE
    inc/GTreeDetectorHits.h
    inc/GTreeTagger.h
    inc/GTreeLinPol.h
+   inc/GTreePairSpec.h
    inc/GTreeScaler.h
    inc/GTreeParticle.h
    inc/GTreeMeson.h
@@ -69,6 +70,7 @@ set(GOAT_BASE
    src/GTreeDetectorHits.cc
    src/GTreeTagger.cc
    src/GTreeLinPol.cc
+   src/GTreePairSpec.cc
    src/GTreeScaler.cc
    src/GTreeParticle.cc
    src/GTreeMeson.cc

--- a/inc/GTreeManager.h
+++ b/inc/GTreeManager.h
@@ -10,6 +10,7 @@
 #include "GTreeTrack.h"
 #include "GTreeTagger.h"
 #include "GTreeLinPol.h"
+#include "GTreePairSpec.h"
 #include "GTreeScaler.h"
 #include "GTreeParticle.h"
 #include "GTreeMeson.h"
@@ -53,6 +54,7 @@ private:
     GTreeTrack*         tracks;
     GTreeTagger*        tagger;
     GTreeLinPol*        linpol;
+    GTreePairSpec*      pairspec;
     GTreeTrigger*       trigger;
     GTreeScaler*        scalers;
 
@@ -81,6 +83,7 @@ protected:
     GTreeTrack*   GetTracks()                 {return tracks;}
     GTreeTagger*        GetTagger()                 {return tagger;}
     GTreeLinPol*        GetLinpol()                 {return linpol;}
+    GTreePairSpec*      GetPairspec()               {return pairspec;}
     GTreeTrigger*       GetTrigger()                {return trigger;}
     GTreeScaler*        GetScalers()                {return scalers;}
 
@@ -106,6 +109,7 @@ protected:
     const   GTreeTrack*   GetTracks()             const       {return tracks;}
     const   GTreeTagger*        GetTagger()             const       {return tagger;}
     const   GTreeLinPol*        GetLinpol()             const       {return linpol;}
+    const   GTreePairSpec*      GetPairspec()           const       {return pairspec;}
     const   GTreeTrigger*       GetTrigger()            const       {return trigger;}
     const   GTreeScaler*        GetScalers()            const       {return scalers;}
 

--- a/inc/GTreePairSpec.h
+++ b/inc/GTreePairSpec.h
@@ -1,0 +1,37 @@
+#ifndef __GTreePairSpec_h__
+#define __GTreePairSpec_h__
+
+
+#include "Rtypes.h"
+#include "GTree.h"
+
+#define GTreePairSpec_MAX 4096
+
+class  GTreePairSpec : public GTree
+{
+private:
+  
+    Double_t    scalerOpen[368];
+    Double_t	scalerGated[368];
+    Double_t	scalerGatedDly[368];
+
+protected:
+    virtual void    SetBranchAdresses();
+    virtual void    SetBranches();
+
+public:
+    GTreePairSpec(GTreeManager *Manager);
+    virtual ~GTreePairSpec();
+
+    virtual void        Clear()     {}
+     const  Double_t*	GetScalerOpen()               const	{return scalerOpen;}
+     const  Double_t	GetScalerOpen(Int_t channel)  const	{return scalerOpen[channel];}
+     const  Double_t*	GetScalerGated()               const	{return scalerGated;}
+     const  Double_t	GetScalerGated(Int_t channel)  const	{return scalerGated[channel];}
+     const  Double_t*	GetScalerGatedDly()               const	{return scalerGatedDly;}
+     const  Double_t	GetScalerGatedDly(Int_t channel)  const	{return scalerGatedDly[channel];}
+
+};
+
+
+#endif

--- a/inc/PTaggEff.h
+++ b/inc/PTaggEff.h
@@ -35,6 +35,7 @@ private:
     TH2*        PairSpecGated;
     TH2*        PairSpecGatedDly;
     TH1*	LiveTimeScal;
+    Bool_t  isPreRecabling;
     Bool_t  FreeScalers;
     Bool_t  HasAttenuation;
     TGraph* Attenuation;

--- a/inc/PTaggEff.h
+++ b/inc/PTaggEff.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "GTreeManager.h"
+#include "GTreePairSpec.h"
 #include "PPhysics.h"
 #include "TF1.h"
 #include "TGraph.h"
@@ -27,6 +28,12 @@ private:
     TH2*	TaggerHits;
     TH2*	TaggerScalers;
     TH2*	TaggerHitScal;
+    TH1*        SumOpenScal;
+    TH1*        SumGatedScal;
+    TH1*        SumGatedDlyScal;
+    TH2*        PairSpecOpen;
+    TH2*        PairSpecGated;
+    TH2*        PairSpecGatedDly;
     TH1*	LiveTimeScal;
     Bool_t  FreeScalers;
     Bool_t  HasAttenuation;

--- a/inc/PTaggEff.h
+++ b/inc/PTaggEff.h
@@ -35,7 +35,6 @@ private:
     TH2*        PairSpecGated;
     TH2*        PairSpecGatedDly;
     TH1*	LiveTimeScal;
-    Bool_t  isPreRecabling;
     Bool_t  FreeScalers;
     Bool_t  HasAttenuation;
     TGraph* Attenuation;

--- a/src/GTreeManager.cc
+++ b/src/GTreeManager.cc
@@ -22,6 +22,7 @@ GTreeManager::GTreeManager()    :
     tracks(0),
     tagger(0),
     linpol(0),
+    pairspec(0),
     trigger(0),
     scalers(0),
     setupParameters(0),
@@ -64,6 +65,7 @@ GTreeManager::GTreeManager()    :
     trigger = new GTreeTrigger(this);
     scalers = new GTreeScaler(this);
     linpol = new GTreeLinPol(this);
+    pairspec = new GTreePairSpec(this);
 #ifdef hasPluto
     pluto = new GTreePluto(this);
 #endif

--- a/src/GTreePairSpec.cc
+++ b/src/GTreePairSpec.cc
@@ -1,0 +1,32 @@
+#include "GTreePairSpec.h"
+
+#include <TLeaf.h>
+
+GTreePairSpec::GTreePairSpec(GTreeManager *Manager)    :
+    GTree(Manager, TString("pairSpec"), kTRUE)
+{
+  for(Int_t i=0; i< 368; i++)
+    {
+        scalerOpen[i] = 0;
+        scalerGated[i] = 0;
+	scalerGatedDly[i] = 0;
+    }
+    
+}
+
+GTreePairSpec::~GTreePairSpec()
+{
+
+}
+
+void    GTreePairSpec::SetBranchAdresses()
+{
+    if(inputTree->GetBranch("scalerOpen")) inputTree->SetBranchAddress("scalerOpen", scalerOpen);
+    if(inputTree->GetBranch("scalerGated")) inputTree->SetBranchAddress("scalerGated", scalerGated);
+    if(inputTree->GetBranch("scalerGatedDly")) inputTree->SetBranchAddress("scalerGatedDly", scalerGatedDly);
+}
+
+void    GTreePairSpec::SetBranches()
+{
+    outputTree = inputTree->CloneTree(0);
+}

--- a/src/PTaggEff.cc
+++ b/src/PTaggEff.cc
@@ -6,6 +6,7 @@ PTaggEff::PTaggEff()
     scalerRead = 0;
     FreeScalers = true;
     HasAttenuation = false;
+    isPreRecabling = false;
 }
 
 PTaggEff::~PTaggEff()
@@ -47,14 +48,29 @@ Bool_t	PTaggEff::Start()
         cout << "ERROR: Input File is not an Acqu file." << endl;
         return kFALSE;
     }
+    // Extract run number
+    std::string inputFileName = GetInputFile(0);
+    
+    int beginIdx = inputFileName.rfind('_');
+    std::string runNumber = inputFileName.substr(beginIdx + 1, 5);
+
+    if(std::stoi(runNumber) < 21850)
+      isPreRecabling = true;
+    
     SetAsGoATFile();
 
     TraverseValidEvents();
 
-    //GoosyTagger(TaggerAccScal);
-    //GoosyVuprom(TaggerAccScal);
-    //GoosyNewFPD(TaggerAccScal);
-    GoosyNewFPDRecabled(TaggerAccScal);
+    if(isPreRecabling)
+    {
+      GoosyNewFPD(TaggerAccScal);
+      cout << endl << endl << "====== New FPD pre recabling! ======"<< endl << endl;
+    }
+  if(!isPreRecabling)
+    {
+      GoosyNewFPDRecabled(TaggerAccScal);
+      cout << endl << endl << "====== New FPD recabled! ======"<< endl << endl;
+    }
 
     return kTRUE;
 }
@@ -216,7 +232,10 @@ void	PTaggEff::ProcessScalerRead()
     TH1D *TaggerCurScal = (TH1D*)TaggerAccScal->Clone("TaggerCurScal");
     TaggerCurScal->Add(TaggerPreScal,-1);
 
-    GoosyNewFPDRecabled(TaggerCurScal);
+    if(isPreRecabling)
+      GoosyNewFPD(TaggerCurScal);
+    if(!isPreRecabling)
+      GoosyNewFPDRecabled(TaggerCurScal);
 
     // Get Pair Spect array
     const Double_t* scalerOpen = GetPairspec() -> GetScalerOpen();

--- a/src/PTaggEff.cc
+++ b/src/PTaggEff.cc
@@ -6,7 +6,6 @@ PTaggEff::PTaggEff()
     scalerRead = 0;
     FreeScalers = true;
     HasAttenuation = false;
-    isPreRecabling = false;
 }
 
 PTaggEff::~PTaggEff()
@@ -48,29 +47,14 @@ Bool_t	PTaggEff::Start()
         cout << "ERROR: Input File is not an Acqu file." << endl;
         return kFALSE;
     }
-    // Extract run number
-    std::string inputFileName = GetInputFile(0);
-    
-    int beginIdx = inputFileName.rfind('_');
-    std::string runNumber = inputFileName.substr(beginIdx + 1, 5);
-
-    if(std::stoi(runNumber) < 21850)
-      isPreRecabling = true;
-    
     SetAsGoATFile();
 
     TraverseValidEvents();
 
-    if(isPreRecabling)
-    {
-      GoosyNewFPD(TaggerAccScal);
-      cout << endl << endl << "====== New FPD pre recabling! ======"<< endl << endl;
-    }
-  if(!isPreRecabling)
-    {
-      GoosyNewFPDRecabled(TaggerAccScal);
-      cout << endl << endl << "====== New FPD recabled! ======"<< endl << endl;
-    }
+    //GoosyTagger(TaggerAccScal);
+    //GoosyVuprom(TaggerAccScal);
+    //GoosyNewFPD(TaggerAccScal);
+    GoosyNewFPDRecabled(TaggerAccScal);
 
     return kTRUE;
 }
@@ -232,10 +216,7 @@ void	PTaggEff::ProcessScalerRead()
     TH1D *TaggerCurScal = (TH1D*)TaggerAccScal->Clone("TaggerCurScal");
     TaggerCurScal->Add(TaggerPreScal,-1);
 
-    if(isPreRecabling)
-      GoosyNewFPD(TaggerCurScal);
-    if(!isPreRecabling)
-      GoosyNewFPDRecabled(TaggerCurScal);
+    GoosyNewFPDRecabled(TaggerCurScal);
 
     // Get Pair Spect array
     const Double_t* scalerOpen = GetPairspec() -> GetScalerOpen();

--- a/src/PTaggEff.cc
+++ b/src/PTaggEff.cc
@@ -73,6 +73,9 @@ void	PTaggEff::ProcessEvent()
         TaggerHits = new TH2D("TaggerHits","Tagger Hits",GetScalers()->GetNEntries(),0,GetScalers()->GetNEntries(),nTaggerChannels,0,nTaggerChannels);
         TaggerScalers = new TH2D("TaggerScalers","Tagger Scalers",GetScalers()->GetNEntries(),0,GetScalers()->GetNEntries(),nTaggerChannels,0,nTaggerChannels);
         TaggerHitScal = new TH2D("TaggerHitScal","Tagger Hits/Scalers",GetScalers()->GetNEntries(),0,GetScalers()->GetNEntries(),nTaggerChannels,0,nTaggerChannels);
+	PairSpecOpen = new TH2D("PairSpecOpen", "Pair Spec Scaler Open", GetScalers()->GetNEntries(),0,GetScalers()->GetNEntries(),nTaggerChannels,0,nTaggerChannels);
+	PairSpecGated = new TH2D("PairSpecGated", "Pair Spec Scaler Gated", GetScalers()->GetNEntries(),0,GetScalers()->GetNEntries(),nTaggerChannels,0,nTaggerChannels);
+	PairSpecGatedDly = new TH2D("PairSpecGatedDly", "Pair Spec Scaler Gated Delayed", GetScalers()->GetNEntries(),0,GetScalers()->GetNEntries(),nTaggerChannels,0,nTaggerChannels);
     }
 
     if(GetDecodeDoubles()) GetTagger()->DecodeDoubles();
@@ -215,11 +218,19 @@ void	PTaggEff::ProcessScalerRead()
 
     GoosyNewFPDRecabled(TaggerCurScal);
 
+    // Get Pair Spect array
+    const Double_t* scalerOpen = GetPairspec() -> GetScalerOpen();
+    const Double_t* scalerGated = GetPairspec() -> GetScalerGated();
+    const Double_t* scalerGatedDly = GetPairspec() -> GetScalerGatedDly();
+
     for (Int_t i = 1; i<=nTaggerChannels; i++)
     {
         TaggerHits->SetBinContent(scalerRead,i,TaggerCurHits->GetBinContent(i));
         TaggerScalers->SetBinContent(scalerRead,i,TaggerCurScal->GetBinContent(i));
         TaggerHitScal->SetBinContent(scalerRead,i,(TaggerCurHits->GetBinContent(i)/TaggerCurScal->GetBinContent(i)));
+	PairSpecOpen->SetBinContent(scalerRead,i,scalerOpen[i-1]);
+	PairSpecGated->SetBinContent(scalerRead,i,scalerGated[i-1]);
+	PairSpecGatedDly->SetBinContent(scalerRead,i,scalerGatedDly[i-1]);
     }
 
     TaggerTime->ProjectionY("TaggerPreHits");
@@ -285,6 +296,18 @@ Bool_t	PTaggEff::Write()
     TaggerScalers->Write();
     TaggerHitScal->Write();
     TaggerTime->Write();
+
+    //Pair spec Sum scaler histos
+    SumOpenScal = PairSpecOpen -> ProjectionY("SumOpenScal",1, PairSpecOpen->GetNbinsX(),"e");
+    SumGatedScal = PairSpecGated -> ProjectionY("SumGatedScal",1, PairSpecGated->GetNbinsX(),"e");
+    SumGatedDlyScal = PairSpecGatedDly -> ProjectionY("SumGatedDlyScal",1, PairSpecGatedDly->GetNbinsX(),"e");
+
+    PairSpecOpen->Write();
+    PairSpecGated->Write();
+    PairSpecGatedDly->Write();
+    SumOpenScal->Write();
+    SumGatedScal->Write();
+    SumGatedDlyScal->Write();
 
     TH1D *TempAllHits = (TH1D*)TaggerAllHits->GetSum()->GetResult()->GetBuffer()->Clone("TempAllHits");
     TH1D *TempSingles = (TH1D*)TaggerSingles->GetSum()->GetResult()->GetBuffer()->Clone("TempSingles");


### PR DESCRIPTION
Hey @werthm and @ppmartel ,

as you can see I tried to add the Pair Spectrometer in GoAT, after I added the tree in AcquRoot. 
The pair spectrometer information can be accessed from any physics class and I already added it to the TaggEff class. It gives also the 2D plots with PS scalers as function of scaler read as well as the SumScaler.  I thought it could be useful in order to avoid to use the "weird" ARHisto file coming from AcquRoot and it gives the possibility to have a pair spectrometer correction scaler read by scaler read, or at least to check the stability. 

If you think it is not really useful, we can also not include it in the master. 
Edoardo